### PR TITLE
Upgraded: sbt, sbt plugins and libs

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.5.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,6 @@ logLevel := sbt.Level.Warn
 
 addSbtPlugin("org.scalameta"   % "sbt-scalafmt"    % "2.4.2")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
-addSbtPlugin("io.kevinlee"     % "sbt-devoops"     % "2.1.0")
+addSbtPlugin("io.kevinlee"     % "sbt-devoops"     % "2.5.0")
 addSbtPlugin("org.scalameta"   % "sbt-mdoc"        % "2.2.13")
-addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.4.0")
-addSbtPlugin("ch.epfl.lamp"    % "sbt-dotty"       % "0.5.4")
+addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.5.0")


### PR DESCRIPTION
# Upgraded: sbt, sbt plugins and libs
* sbt `1.5.0` => `1.5.3`
* sbt-devoops `2.1.0` => `2.5.0`
* sbt-docusaur `0.4.0` => `0.5.0`
* Removed: `sbt-dotty`
* refined `0.9.23` => `0.9.26`
* hedgehog `0.6.5` => `0.7.0`