### PR TITLE
hedgehog-extra v0.1.0

### DIFF
--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,166 @@
+## [0.1.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone1) - 2022-12-18
+
+## New Features
+* Add `NumGens` with negative, non-negative, positive and non-positive `Int` (#3)
+  ```scala
+  import eu.timepit.refined.auto._
+  import eu.timepit.refined.types.numeric._
+  import hedgehog.extra.refined.NumGens
+
+  NumGens.genNegInt(NegInt(-100), NegInt(-1))
+  // the same as
+  Gen.int(Range.linear(-100, -1)).map(NegInt.unsafeFrom) // Gen[NegInt]
+
+  NumGens.genNegIntMinTo(NegInt(-100))
+  // the same as
+  genNegInt(NegInt(-100), NegInt.MaxValue) // Gen[NegInt]
+
+  NumGens.genNonPosInt(NonPosInt(-100), NonPosInt(0))
+  // the same as
+  Gen.int(Range.linear(-100, 0)).map(NonPosInt.unsafeFrom) // Gen[NonPosInt]
+
+  NumGens.genNonPosIntMinTo(NonPosInt(-100))
+  // the same as
+  genNonPosInt(-100, NonPosInt.MaxValue) // Gen[NonPosInt]
+
+  NumGens.genPosInt(PosInt(1), PosInt(100))
+  // the same as
+  Gen.int(Range.linear(1, 100)).map(PosInt.unsafeFrom) // Gen[PosInt]
+
+  NumGens.genPosIntMaxTo(PosInt(100))
+  // the same as
+  genPosInt(PosInt.MinValue, PosInt(100)) // Gen[PosInt]
+
+  NumGens.genNonNegInt(NonNegInt(0), NonNegInt(100))
+  // the same as
+  Gen.int(Range.linear(0, 100)).map(NonNegInt.unsafeFrom) // Gen[NonNegInt]
+
+  NumGens.genNonNegIntMaxTo(NonNegInt(100))
+  // the same as
+  genNonNegInt(NonNegInt.MinValue, NonNegInt(100)) // Gen[NonNegInt]
+  ```
+* Add `NumGens` with negative, non-negative, positive and non-positive `Long` (#4)
+  ```scala
+  import eu.timepit.refined.auto._
+  import eu.timepit.refined.types.numeric._
+  import hedgehog.extra.refined.NumGens
+
+  NumGens.genNegLong(NegLong(-100L), NegLong(-1L))
+  // the same as
+  Gen.long(Range.linear(-100L, -1L)).map(NegLong.unsafeFrom) // Gen[NegLong]
+
+  NumGens.genNegLongMinTo(NegLong(-100L))
+  // the same as
+  genNegLong(NegLong(-100L), NegLong.MaxValue) // Gen[NegLong]
+
+  NumGens.genNonPosLong(NonPosLong(-100L), NonPosLong(0L))
+  // the same as
+  Gen.long(Range.linear(-100L, 0L)).map(NonPosLong.unsafeFrom) // Gen[NonPosLong]
+
+  NumGens.genNonPosLongMinTo(NonPosLong(-100L))
+  // the same as
+  genNonPosLong(-100L, NonPosLong.MaxValue) // Gen[NonPosLong]
+
+  NumGens.genPosLong(PosLong(1L), PosLong(100L))
+  // the same as
+  Gen.long(Range.linear(1L, 100L)).map(PosLong.unsafeFrom) // Gen[PosLong]
+
+  NumGens.genPosLongMaxTo(PosLong(100L))
+  // the same as
+  genPosLong(PosLong.MinValue, PosLong(100L)) // Gen[PosLong]
+
+  NumGens.genNonNegLong(NonNegLong(0L), NonNegLong(100L))
+  // the same as
+  Gen.long(Range.linear(0L, 100L)).map(NonNegLong.unsafeFrom) // Gen[NonNegLong]
+
+  NumGens.genNonNegLongMaxTo(NonNegLong(100L))
+  // the same as
+  genNonNegLong(NonNegLong.MinValue, NonNegLong(100L)) // Gen[NonNegLong]
+  ```
+* Redesign `Gen`s for numbers with already defined numbers from refined and add `Gen`s for `Double` (#18)
+  ```scala
+  import eu.timepit.refined.auto._
+  import eu.timepit.refined.types.numeric._
+  import hedgehog.extra.refined.NumGens
+
+  NumGens.genNegDouble(NegDouble(-100D), NegDouble(-1D))
+  // the same as
+  Gen.double(Range.linearFrac(-100D, -1D)).map(NegDouble.unsafeFrom) // Gen[NegDouble]
+
+  NumGens.genNegDoubleMinTo(NegDouble(-100D))
+  // the same as
+  genNegDouble(NegDouble(-100D), NegDouble.MaxValue) // Gen[NegDouble]
+
+  NumGens.genNonPosDouble(NonPosDouble(-100D), NonPosDouble(0D))
+  // the same as
+  Gen.double(Range.linearFrac(-100D, 0D)).map(NonPosDouble.unsafeFrom) // Gen[NonPosDouble]
+
+  NumGens.genNonPosDoubleMinTo(NonPosDouble(-100D))
+  // the same as
+  genNonPosDouble(-100D, NonPosDouble.MaxValue) // Gen[NonPosDouble]
+
+  NumGens.genPosDouble(PosDouble(1D), PosDouble(100D))
+  // the same as
+  Gen.double(Range.linearFrac(1D, 100D)).map(PosDouble.unsafeFrom) // Gen[PosDouble]
+
+  NumGens.genPosDoubleMaxTo(PosDouble(100D))
+  // the same as
+  genPosDouble(PosDouble.MinValue, PosDouble(100D)) // Gen[PosDouble]
+
+  NumGens.genNonNegDouble(NonNegDouble(0D), NonNegDouble(100D))
+  // the same as
+  Gen.double(Range.linearFrac(0D, 100D)).map(NonNegDouble.unsafeFrom) // Gen[NonNegDouble]
+
+  NumGens.genNonNegDoubleMaxTo(NonNegDouble(100D))
+  // the same as
+  genNonNegDouble(NonNegDouble.MinValue, NonNegDouble(100D)) // Gen[NonNegDouble]
+  ```
+* Add `Gen[Char]` with `Char` ranges (`List[(Int, Int)`]) (#11)
+  ```scala
+  import hedgehog.extra.Gens
+  
+  Gens.genCharByRange(List(1 -> 10, 100 -> 200, 201 -> 203))
+  // the same as
+  Gen.frequencyUnsafe(List(
+    10  -> Gen.char(1, 10),
+    100 -> Gen.char(100, 200),
+    3   -> Gen.char(201, 203)
+  ))
+  ```
+* Add `Gen` to generate non-whitespace String (#14)
+  ```scala
+  import hedgehog.extra.Gens
+  
+  Gens.genUnsafeNonWhitespaceString(10)
+  // non-empty and non-whitespace String up to the length of 10.
+  ```
+  ```scala
+  import eu.timepit.refined.auto._
+  import eu.timepit.refined.types.numeric.PosInt
+  import hedgehog.extra.refined.StringGens
+  
+  StringGens.genNonWhitespaceString(PosInt(10))
+  // non-whitespace NonEmptyString up to the length of 10.
+  ```
+* Add `NetGens` with `PortNumber` generator (#33)
+  ```scala
+  NetGens.genPortNumber
+  // returns Gen[PortNumber] with possible PortNumber(0 - 65535)
+  
+  NetGens.genSystemPortNumber
+  // returns Gen[SystemPortNumber] with possible SystemPortNumber(0 - 1023)
+  
+  NetGens.genUserPortNumber
+  // returns Gen[UserPortNumber] with possible UserPortNumber(1024 - 49151)
+  
+  NetGens.genDynamicPortNumber
+  // returns Gen[DynamicPortNumber] with possible DynamicPortNumber(49152 - 65535)
+  
+  NetGens.genNonSystemPortNumber
+  // returns Gen[NonSystemPortNumber] with possible NonSystemPortNumber(1024 - 65535)
+  ``` 
+
+
+## Internal Housekeeping
+* Move sub-projects to modules (#19)
+* Fix module names - remove `scala-` prefix (#27)


### PR DESCRIPTION
# hedgehog-extra v0.1.0
## [0.1.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone1) - 2022-12-18

## New Features
* Add `NumGens` with negative, non-negative, positive and non-positive `Int` (#3)
  ```scala
  import eu.timepit.refined.auto._
  import eu.timepit.refined.types.numeric._
  import hedgehog.extra.refined.NumGens

  NumGens.genNegInt(NegInt(-100), NegInt(-1))
  // the same as
  Gen.int(Range.linear(-100, -1)).map(NegInt.unsafeFrom) // Gen[NegInt]

  NumGens.genNegIntMinTo(NegInt(-100))
  // the same as
  genNegInt(NegInt(-100), NegInt.MaxValue) // Gen[NegInt]

  NumGens.genNonPosInt(NonPosInt(-100), NonPosInt(0))
  // the same as
  Gen.int(Range.linear(-100, 0)).map(NonPosInt.unsafeFrom) // Gen[NonPosInt]

  NumGens.genNonPosIntMinTo(NonPosInt(-100))
  // the same as
  genNonPosInt(-100, NonPosInt.MaxValue) // Gen[NonPosInt]

  NumGens.genPosInt(PosInt(1), PosInt(100))
  // the same as
  Gen.int(Range.linear(1, 100)).map(PosInt.unsafeFrom) // Gen[PosInt]

  NumGens.genPosIntMaxTo(PosInt(100))
  // the same as
  genPosInt(PosInt.MinValue, PosInt(100)) // Gen[PosInt]

  NumGens.genNonNegInt(NonNegInt(0), NonNegInt(100))
  // the same as
  Gen.int(Range.linear(0, 100)).map(NonNegInt.unsafeFrom) // Gen[NonNegInt]

  NumGens.genNonNegIntMaxTo(NonNegInt(100))
  // the same as
  genNonNegInt(NonNegInt.MinValue, NonNegInt(100)) // Gen[NonNegInt]
  ```
* Add `NumGens` with negative, non-negative, positive and non-positive `Long` (#4)
  ```scala
  import eu.timepit.refined.auto._
  import eu.timepit.refined.types.numeric._
  import hedgehog.extra.refined.NumGens

  NumGens.genNegLong(NegLong(-100L), NegLong(-1L))
  // the same as
  Gen.long(Range.linear(-100L, -1L)).map(NegLong.unsafeFrom) // Gen[NegLong]

  NumGens.genNegLongMinTo(NegLong(-100L))
  // the same as
  genNegLong(NegLong(-100L), NegLong.MaxValue) // Gen[NegLong]

  NumGens.genNonPosLong(NonPosLong(-100L), NonPosLong(0L))
  // the same as
  Gen.long(Range.linear(-100L, 0L)).map(NonPosLong.unsafeFrom) // Gen[NonPosLong]

  NumGens.genNonPosLongMinTo(NonPosLong(-100L))
  // the same as
  genNonPosLong(-100L, NonPosLong.MaxValue) // Gen[NonPosLong]

  NumGens.genPosLong(PosLong(1L), PosLong(100L))
  // the same as
  Gen.long(Range.linear(1L, 100L)).map(PosLong.unsafeFrom) // Gen[PosLong]

  NumGens.genPosLongMaxTo(PosLong(100L))
  // the same as
  genPosLong(PosLong.MinValue, PosLong(100L)) // Gen[PosLong]

  NumGens.genNonNegLong(NonNegLong(0L), NonNegLong(100L))
  // the same as
  Gen.long(Range.linear(0L, 100L)).map(NonNegLong.unsafeFrom) // Gen[NonNegLong]

  NumGens.genNonNegLongMaxTo(NonNegLong(100L))
  // the same as
  genNonNegLong(NonNegLong.MinValue, NonNegLong(100L)) // Gen[NonNegLong]
  ```
* Redesign `Gen`s for numbers with already defined numbers from refined and add `Gen`s for `Double` (#18)
  ```scala
  import eu.timepit.refined.auto._
  import eu.timepit.refined.types.numeric._
  import hedgehog.extra.refined.NumGens

  NumGens.genNegDouble(NegDouble(-100D), NegDouble(-1D))
  // the same as
  Gen.double(Range.linearFrac(-100D, -1D)).map(NegDouble.unsafeFrom) // Gen[NegDouble]

  NumGens.genNegDoubleMinTo(NegDouble(-100D))
  // the same as
  genNegDouble(NegDouble(-100D), NegDouble.MaxValue) // Gen[NegDouble]

  NumGens.genNonPosDouble(NonPosDouble(-100D), NonPosDouble(0D))
  // the same as
  Gen.double(Range.linearFrac(-100D, 0D)).map(NonPosDouble.unsafeFrom) // Gen[NonPosDouble]

  NumGens.genNonPosDoubleMinTo(NonPosDouble(-100D))
  // the same as
  genNonPosDouble(-100D, NonPosDouble.MaxValue) // Gen[NonPosDouble]

  NumGens.genPosDouble(PosDouble(1D), PosDouble(100D))
  // the same as
  Gen.double(Range.linearFrac(1D, 100D)).map(PosDouble.unsafeFrom) // Gen[PosDouble]

  NumGens.genPosDoubleMaxTo(PosDouble(100D))
  // the same as
  genPosDouble(PosDouble.MinValue, PosDouble(100D)) // Gen[PosDouble]

  NumGens.genNonNegDouble(NonNegDouble(0D), NonNegDouble(100D))
  // the same as
  Gen.double(Range.linearFrac(0D, 100D)).map(NonNegDouble.unsafeFrom) // Gen[NonNegDouble]

  NumGens.genNonNegDoubleMaxTo(NonNegDouble(100D))
  // the same as
  genNonNegDouble(NonNegDouble.MinValue, NonNegDouble(100D)) // Gen[NonNegDouble]
  ```
* Add `Gen[Char]` with `Char` ranges (`List[(Int, Int)`]) (#11)
  ```scala
  import hedgehog.extra.Gens
  
  Gens.genCharByRange(List(1 -> 10, 100 -> 200, 201 -> 203))
  // the same as
  Gen.frequencyUnsafe(List(
    10  -> Gen.char(1, 10),
    100 -> Gen.char(100, 200),
    3   -> Gen.char(201, 203)
  ))
  ```
* Add `Gen` to generate non-whitespace String (#14)
  ```scala
  import hedgehog.extra.Gens
  
  Gens.genUnsafeNonWhitespaceString(10)
  // non-empty and non-whitespace String up to the length of 10.
  ```
  ```scala
  import eu.timepit.refined.auto._
  import eu.timepit.refined.types.numeric.PosInt
  import hedgehog.extra.refined.StringGens
  
  StringGens.genNonWhitespaceString(PosInt(10))
  // non-whitespace NonEmptyString up to the length of 10.
  ```
* Add `NetGens` with `PortNumber` generator (#33)
  ```scala
  NetGens.genPortNumber
  // returns Gen[PortNumber] with possible PortNumber(0 - 65535)
  
  NetGens.genSystemPortNumber
  // returns Gen[SystemPortNumber] with possible SystemPortNumber(0 - 1023)
  
  NetGens.genUserPortNumber
  // returns Gen[UserPortNumber] with possible UserPortNumber(1024 - 49151)
  
  NetGens.genDynamicPortNumber
  // returns Gen[DynamicPortNumber] with possible DynamicPortNumber(49152 - 65535)
  
  NetGens.genNonSystemPortNumber
  // returns Gen[NonSystemPortNumber] with possible NonSystemPortNumber(1024 - 65535)
  ``` 


## Internal Housekeeping
* Move sub-projects to modules (#19)
* Fix module names - remove `scala-` prefix (#27)
