### PR TITLE
hedgehog-extra v0.2.0

### DIFF
--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,8 @@
+## [0.2.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone2) - 2022-12-25 🎄
+
+## New Feature
+* Add `StringGens.genNonEmptyString` (#43)
+  ```scala
+  StringGens.genNonEmptyString(Gen.alphaNum, PosInt(10))
+  // Gen[NonEmptyString] - NonEmptyString contains alphabet or number with the max length up to 10
+  ```


### PR DESCRIPTION
# hedgehog-extra v0.2.0
## [0.2.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone2) - 2022-12-25 🎄

## New Feature
* Add `StringGens.genNonEmptyString` (#43)
  ```scala
  StringGens.genNonEmptyString(Gen.alphaNum, PosInt(10))
  // Gen[NonEmptyString] - NonEmptyString contains alphabet or number with the max length up to 10
  ```
