### PR TITLE
hedgehog-extra v0.3.0

### DIFF
--- a/changelogs/0.3.0.md
+++ b/changelogs/0.3.0.md
@@ -1,0 +1,44 @@
+## [0.3.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone3) - 2023-01-26 🇦🇺
+
+## New Features
+* Add `Gen` for min and max pair for `Int` and `Long` (#52)
+  ```scala
+  import hedgehog.extra.NumGens
+  
+  NumGens.genIntMinMaxPair(1, 100)
+  // result might be like
+  // (1, 100)
+  // (10, 10)
+  // (42, 71)
+  // ...
+  ```
+  ```scala
+  import hedgehog.extra.NumGens
+  
+  NumGens.genLongMinMaxPair(1L, 100L)
+  // result might be like
+  // (1L, 100L)
+  // (10L, 10L)
+  // (42L, 71L)
+  // ...
+  ```
+* [`hedgehog-extra-refined`] Add `TimeGens` for `eu.timepit.refined.types.time` types (#54)
+  ```scala
+  def genMonthMinMax(min: Month, max: Month): Gen[Month]
+  def genMonth: Gen[Month]
+  
+  def genDayMinMax(min: Day, max: Day): Gen[Day]
+  def genDay: Gen[Day]
+  
+  def genHourMinMax(min: Hour, max: Hour): Gen[Hour]
+  def genHour(min: Hour, max: Hour): Gen[Hour]
+  
+  def genMinuteMinMax(min: Minute, max: Minute): Gen[Minute]
+  def genMinute: Gen[Minute]
+  
+  def genSecondMinMax(min: Second, max: Second): Gen[Second]
+  def genSecond: Gen[Second]
+  
+  def genMillisMinMax(min: Millis, max: Millis): Gen[Millis]
+  def genMillis: Gen[Millis]
+  ```


### PR DESCRIPTION
# hedgehog-extra v0.3.0
## [0.3.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone3) - 2023-01-26 🇦🇺

## New Features
* Add `Gen` for min and max pair for `Int` and `Long` (#52)
  ```scala
  import hedgehog.extra.NumGens
  
  NumGens.genIntMinMaxPair(1, 100)
  // result might be like
  // (1, 100)
  // (10, 10)
  // (42, 71)
  // ...
  ```
  ```scala
  import hedgehog.extra.NumGens
  
  NumGens.genLongMinMaxPair(1L, 100L)
  // result might be like
  // (1L, 100L)
  // (10L, 10L)
  // (42L, 71L)
  // ...
  ```
* [`hedgehog-extra-refined`] Add `TimeGens` for `eu.timepit.refined.types.time` types (#54)
  ```scala
  def genMonthMinMax(min: Month, max: Month): Gen[Month]
  def genMonth: Gen[Month]
  
  def genDayMinMax(min: Day, max: Day): Gen[Day]
  def genDay: Gen[Day]
  
  def genHourMinMax(min: Hour, max: Hour): Gen[Hour]
  def genHour(min: Hour, max: Hour): Gen[Hour]
  
  def genMinuteMinMax(min: Minute, max: Minute): Gen[Minute]
  def genMinute: Gen[Minute]
  
  def genSecondMinMax(min: Second, max: Second): Gen[Second]
  def genSecond: Gen[Second]
  
  def genMillisMinMax(min: Millis, max: Millis): Gen[Millis]
  def genMillis: Gen[Millis]
  ```
