### PR TITLE
hedgehog-extra v0.4.0

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,4 @@
+## [0.4.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone4) - 2023-04-16
+
+## Added
+* Support Scala 3 (#67)


### PR DESCRIPTION
# hedgehog-extra v0.4.0
## [0.4.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone4) - 2023-04-16

## Added
* Support Scala 3 (#67)
