### PR TITLE
hedgehog-extra v0.5.0

### DIFF
--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,0 +1,24 @@
+## [0.5.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am5) - 2023-01-04
+
+## New Features
+* [`hedgehog-extra-refined`] Add `StringGens.genNonEmptyStringMinMax` (#71)
+  ```scala
+  import hedgehog.extra.Gens
+  import hedgehog.extra.refined.StringGens
+  
+  StringGens.genNonEmptyStringMinMax(Gens.genNonWhitespaceChar, PosInt(1), PosInt(10)) 
+  ```
+
+* [`hedgehog-extra-core`] Add `Gens.genUnsafeNonWhitespaceStringMinMax` (#73)
+  ```scala
+  import hedgehog.extra.Gens
+
+  Gens.genUnsafeNonWhitespaceStringMinMax(1, 10)
+  ```
+
+* [`hedgehog-extra-refined`] Add `StringGens.genNonWhitespaceStringMinMax` (#75)
+  ```scala
+  import hedgehog.extra.refined.StringGens
+
+  StringGens.genNonWhitespaceStringMinMax(PosInt(10), PosInt(100))
+  ```


### PR DESCRIPTION
# hedgehog-extra v0.5.0
## [0.5.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am5) - 2023-01-04

## New Features
* [`hedgehog-extra-refined`] Add `StringGens.genNonEmptyStringMinMax` (#71)
  ```scala
  import hedgehog.extra.Gens
  import hedgehog.extra.refined.StringGens
  
  StringGens.genNonEmptyStringMinMax(Gens.genNonWhitespaceChar, PosInt(1), PosInt(10)) 
  ```

* [`hedgehog-extra-core`] Add `Gens.genUnsafeNonWhitespaceStringMinMax` (#73)
  ```scala
  import hedgehog.extra.Gens

  Gens.genUnsafeNonWhitespaceStringMinMax(1, 10)
  ```

* [`hedgehog-extra-refined`] Add `StringGens.genNonWhitespaceStringMinMax` (#75)
  ```scala
  import hedgehog.extra.refined.StringGens

  StringGens.genNonWhitespaceStringMinMax(PosInt(10), PosInt(100))
  ```
