### PR TITLE
hedgehog-extra v0.6.0

### DIFF
--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -1,0 +1,7 @@
+## [0.6.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am6) - 2023-01-05
+
+## New Features
+* Add `hedgehog-extra-refined4s` to provide `Gen`s for `refined4s`'s pre-defined types (#80)
+
+## Change
+* Upgrade Scala 3 to `3.1.3` (#83)


### PR DESCRIPTION
# hedgehog-extra v0.6.0
## [0.6.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am6) - 2023-01-05

## New Features
* Add `hedgehog-extra-refined4s` to provide `Gen`s for `refined4s`'s pre-defined types (#80)

## Change
* Upgrade Scala 3 to `3.1.3` (#83)
