### PR TITLE
hedgehog-extra v0.7.0

### DIFF
--- a/changelogs/0.7.0.md
+++ b/changelogs/0.7.0.md
@@ -1,0 +1,5 @@
+## [0.7.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am7) - 2023-01-22
+
+## Internal Housekeeping
+
+* Upgrade `refined4s` to `0.13.0` (#90)


### PR DESCRIPTION
# hedgehog-extra v0.7.0
## [0.7.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am7) - 2023-01-22

## Internal Housekeeping

* Upgrade `refined4s` to `0.13.0` (#90)
