### PR TITLE
scala-hedgehog-extra v0.8.0

### DIFF
--- a/changelogs/0.8.0.md
+++ b/changelogs/0.8.0.md
@@ -1,0 +1,6 @@
+## [0.8.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am8) - 2024-02-27
+
+## New Features
+
+* [`hedgehog-extra-core`] Add `TimeGens.genInstant` to generate `java.time.Instant` with range (#95)
+* [`hedgehog-extra-core`] Add `TimeGens.genInstantFrom` to generate `java.time.Instant` with duration range (#97)


### PR DESCRIPTION
# scala-hedgehog-extra v0.8.0
## [0.8.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am8) - 2024-02-27

## New Features

* [`hedgehog-extra-core`] Add `TimeGens.genInstant` to generate `java.time.Instant` with range (#95)
* [`hedgehog-extra-core`] Add `TimeGens.genInstantFrom` to generate `java.time.Instant` with duration range (#97)
