### PR TITLE
scala-hedgehog-extra v0.10.0

### DIFF
--- a/changelogs/0.10.0.md
+++ b/changelogs/0.10.0.md
@@ -1,0 +1,9 @@
+## [0.10.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am10) - 2024-09-09
+
+## New Features
+
+* Add Scala.js support (#118)
+
+  **NOTE**: Because `refined4s`'s Scala.js support has an issue, `hedgehog-extra-refined4s` is not available for Scala.js yet. It will be available when `refined4s`'s Scala.js support is fixed.
+ 
+  **NOTE 2**: Scala 2.11 support for `hedgehog-extra-refined` is dropped. It's because there is no `refined` for Scala 2.11 supporting Scala.js.


### PR DESCRIPTION
# scala-hedgehog-extra v0.10.0
## [0.10.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am10) - 2024-09-09

## New Features

* Add Scala.js support (#118)

  **NOTE**: Because `refined4s`'s Scala.js support has an issue, `hedgehog-extra-refined4s` is not available for Scala.js yet. It will be available when `refined4s`'s Scala.js support is fixed.
 
  **NOTE 2**: Scala 2.11 support for `hedgehog-extra-refined` is dropped. It's because there is no `refined` for Scala 2.11 supporting Scala.js.
