### PR TITLE
scala-hedgehog-extra v0.11.0

### DIFF
--- a/changelogs/0.11.0.md
+++ b/changelogs/0.11.0.md
@@ -1,0 +1,9 @@
+## [0.11.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am11) - 2024-11-05
+
+## New Features
+
+* Add Scala.js support for `hedgehog-extra-refined4s` again (#122)
+
+  Because `refined4s`'s `Scala.js` support had an issue, `hedgehog-extra-refined4s` was not available for Scala.js ([0.10.0 RELEASE NOTE](https://github.com/kevin-lee/scala-hedgehog-extra/releases/tag/v0.10.0)).
+
+  The issue with `refined4s` has been fixed, so now `hedgehog-extra-refined4s` can have `Scala.js` support.


### PR DESCRIPTION
# scala-hedgehog-extra v0.11.0
## [0.11.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am11) - 2024-11-05

## New Features

* Add Scala.js support for `hedgehog-extra-refined4s` again (#122)

  Because `refined4s`'s `Scala.js` support had an issue, `hedgehog-extra-refined4s` was not available for Scala.js ([0.10.0 RELEASE NOTE](https://github.com/kevin-lee/scala-hedgehog-extra/releases/tag/v0.10.0)).

  The issue with `refined4s` has been fixed, so now `hedgehog-extra-refined4s` can have `Scala.js` support.
