### PR TITLE
Upgrade `sbt` to `1.11.1` and the `sbt-ci-release` plugin to `1.11.1` / clean up unused build settings related to the old Maven Central (OSSRH)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ ThisBuild / scmInfo :=
   )
 
 ThisBuild / licenses := props.Licenses
-ThisBuild / resolvers += "sonatype-snapshots" at s"https://${props.SonatypeCredentialHost}/content/repositories/snapshots"
 
 ThisBuild / scalafixConfig := (
   if (scalaVersion.value.startsWith("3")) file(".scalafix-scala3.conf").some
@@ -38,7 +37,6 @@ lazy val hedgehogExtra = Project(props.ProjectName, file("."))
   .settings(
     libraryDependencies := removeDottyIncompatible(isScala3(scalaVersion.value), libraryDependencies.value)
   )
-  .settings(mavenCentralPublishSettings)
   .settings(noPublish)
   .settings(noDoc)
   .aggregate(
@@ -122,9 +120,6 @@ lazy val props =
 
     val Licenses = List("MIT" -> url("http://opensource.org/licenses/MIT"))
 
-    val SonatypeCredentialHost = "s01.oss.sonatype.org"
-    val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
-
     val removeDottyIncompatible: ModuleID => Boolean =
       m =>
         m.name == "wartremover" ||
@@ -173,13 +168,6 @@ def removeDottyIncompatible(isScala3: Boolean, libraries: Seq[ModuleID]): Seq[Mo
     libraries.filterNot(props.removeDottyIncompatible).distinct
   else
     libraries.distinct
-
-lazy val mavenCentralPublishSettings: SettingsDefinition = List(
-  /* Publish to Maven Central { */
-  sonatypeCredentialHost := props.SonatypeCredentialHost,
-  sonatypeRepository := props.SonatypeRepository,
-  /* } Publish to Maven Central */
-)
 
 // format: off
 def prefixedProjectName(name: String) = s"${props.ProjectName}${if (name.isEmpty) "" else s"-$name"}"
@@ -255,7 +243,6 @@ def subProject(projectName: ProjectName, crossProject: CrossProject.Builder): Cr
       /* } Ammonite-REPL */
 
     )
-    .settings(mavenCentralPublishSettings)
 
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")


### PR DESCRIPTION
Upgrade `sbt` to `1.11.1` and the `sbt-ci-release` plugin to `1.11.1` / clean up unused build settings related to the old Maven Central (OSSRH).

Due to the end-of-life (sunset) of OSSRH, upgrading `sbt` to `1.11.1` and `sbt-ci-release` to `1.11.1` was required in order to publish artifacts to the Central Publisher Portal (Maven Central).