### PR TITLE
Fix GitHub username casing and fix the repository name in `build.sbt`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,10 +101,10 @@ lazy val props =
   new {
     val Org = "io.kevinlee"
 
-    val GitHubUsername = "Kevin-Lee"
+    val GitHubUsername = "kevin-lee"
 
     val ProjectName = "hedgehog-extra"
-    val RepoName    = "scala-" + ProjectOrigin
+    val RepoName    = "scala-" + ProjectName
 
     val Scala2Version = "2.13.15"
     val Scala3Version = "3.3.4"


### PR DESCRIPTION
Fix GitHub username casing and fix the repository name in `build.sbt`