### PR TITLE
scala-hedgehog-extra v0.12.0

### DIFF
--- a/changelogs/0.12.0.md
+++ b/changelogs/0.12.0.md
@@ -1,0 +1,5 @@
+## [0.12.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am12) - 2025-08-15
+
+## New Features
+
+Close #134: [`hedgehog-extra-core`] Support Scala Native


### PR DESCRIPTION
# scala-hedgehog-extra v0.12.0
## [0.12.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am12) - 2025-08-15

## New Features

Close #134: [`hedgehog-extra-core`] Support Scala Native
