### PR TITLE
Close #139: [`hedgehog-extra-core`] Add missing support for Scala Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val hedgehogExtra = Project(props.ProjectName, file("."))
   .aggregate(
     extraCoreJvm,
     extraCoreJs,
+    extraCoreNative,
     extraRefinedJvm,
     extraRefinedJs,
     extraRefined4sJvm,

--- a/modules/hedgehog-extra-core/native/src/main/scala/hedgehog/extra/common.scala
+++ b/modules/hedgehog-extra-core/native/src/main/scala/hedgehog/extra/common.scala
@@ -1,0 +1,21 @@
+package hedgehog.extra
+
+/** @author Kevin Lee
+  * @since 2021-04-06
+  */
+object common {
+
+  final val NonWhitespaceCharRange: List[(Int, Int)] = List( // scalafix:ok DisableSyntax.noFinalVal
+    0     -> 8,
+    14    -> 27,
+    33    -> 5759,
+    5761  -> 6157,
+    6159  -> 8191,
+    8199  -> 8199,
+    8203  -> 8231,
+    8234  -> 8286,
+    8288  -> 12287,
+    12289 -> Char.MaxValue.toInt
+  )
+
+}

--- a/modules/hedgehog-extra-core/shared/src/main/scala/hedgehog/extra/Gens.scala
+++ b/modules/hedgehog-extra-core/shared/src/main/scala/hedgehog/extra/Gens.scala
@@ -16,7 +16,7 @@ trait Gens {
     )
 
   def genNonWhitespaceChar: Gen[Char] =
-    genCharByRange(common.NonWhitespaceCharRange)
+    genCharByRange(hedgehog.extra.common.NonWhitespaceCharRange)
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def genUnsafeNonWhitespaceString(maxLength: Int): Gen[String] =


### PR DESCRIPTION
Close #139: [`hedgehog-extra-core`] Add missing support for Scala Native