### PR TITLE
scala-hedgehog-extra v0.13.0

### DIFF
--- a/changelogs/0.13.0.md
+++ b/changelogs/0.13.0.md
@@ -1,0 +1,6 @@
+## [0.13.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am13) - 2025-08-17
+
+## New Features
+
+* [`hedgehog-extra-core`] Support Scala Native (#139)
+* [`hedgehog-extra-refined4s`] Support Scala Native (#142)


### PR DESCRIPTION
# scala-hedgehog-extra v0.13.0
## [0.13.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am13) - 2025-08-17

## New Features

* [`hedgehog-extra-core`] Support Scala Native (#139)
* [`hedgehog-extra-refined4s`] Support Scala Native (#142)
