### PR TITLE
hedgehog-extra v0.14.0

### DIFF
--- a/changelogs/0.14.0.md
+++ b/changelogs/0.14.0.md
@@ -1,0 +1,10 @@
+## [0.14.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am14) - 2025-08-27
+
+## Changes
+
+* Bump `refined4s` to `1.8.1` (#151)
+
+  The following type class instance import is no longer required.
+  ```scala 3
+  import refined4s.modules.cats.derivation.types.all.given
+  ```


### PR DESCRIPTION
# hedgehog-extra v0.14.0
## [0.14.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am14) - 2025-08-27

## Changes

* Bump `refined4s` to `1.8.1` (#151)

  The following type class instance import is no longer required.
  ```scala 3
  import refined4s.modules.cats.derivation.types.all.given
  ```
