### PR TITLE
hedgehog-extra v0.15.0

### DIFF
--- a/changelogs/0.15.0.md
+++ b/changelogs/0.15.0.md
@@ -1,0 +1,5 @@
+## [0.15.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am15) - 2025-09-06
+
+## Changes
+
+* Bump `refined4s` to `1.9.0` (#155)


### PR DESCRIPTION
# hedgehog-extra v0.15.0
## [0.15.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am15) - 2025-09-06

## Changes

* Bump `refined4s` to `1.9.0` (#155)
