### PR TITLE
Close #164: Bump `refined4s` to `1.11.0`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -183,7 +183,7 @@ lazy val props =
 
     val HedgehogVersion = "0.13.0"
 
-    val Refined4sVersion = "1.10.1"
+    val Refined4sVersion = "1.11.0"
 
     val ScalaNativeCryptoVersion = "0.2.1"
 


### PR DESCRIPTION
Close #164: Bump `refined4s` to `1.11.0`