### PR TITLE
hedgehog-extra v0.17.0

### DIFF
--- a/changelogs/0.17.0.md
+++ b/changelogs/0.17.0.md
@@ -1,0 +1,5 @@
+## [0.17.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am17) - 2025-09-29
+
+## Changes
+
+* Bump `refined4s` to `1.11.0` (#164)


### PR DESCRIPTION
# hedgehog-extra v0.17.0
## [0.17.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am17) - 2025-09-29

## Changes

* Bump `refined4s` to `1.11.0` (#164)
