### PR TITLE
hedgehog-extra v0.18.0

### DIFF
--- a/changelogs/0.18.0.md
+++ b/changelogs/0.18.0.md
@@ -1,0 +1,5 @@
+## [0.18.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am18) - 2025-11-03
+
+## Changes
+
+* [`hedgehog-extra-refined4s`] Bump `refined4s` to `1.2.0` (#170)


### PR DESCRIPTION
# hedgehog-extra v0.18.0
## [0.18.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am18) - 2025-11-03

## Changes

* [`hedgehog-extra-refined4s`] Bump `refined4s` to `1.2.0` (#170)
