### PR TITLE
hedgehog-extra v0.19.0

### DIFF
--- a/changelogs/0.18.0.md
+++ b/changelogs/0.18.0.md
@@ -2,4 +2,4 @@
 
 ## Changes
 
-* [`hedgehog-extra-refined4s`] Bump `refined4s` to `1.2.0` (#170)
+* [`hedgehog-extra-refined4s`] Bump `refined4s` to `1.12.0` (#170)

--- a/changelogs/0.19.0.md
+++ b/changelogs/0.19.0.md
@@ -1,0 +1,5 @@
+## [0.19.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am19) - 2025-11-06
+
+## Changes
+
+* [`hedgehog-extra-refined4s`] Bump `refined4s` to `1.13.0` (#173)


### PR DESCRIPTION
# hedgehog-extra v0.19.0
## [0.19.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am19) - 2025-11-06

## Changes

* [`hedgehog-extra-refined4s`] Bump `refined4s` to `1.13.0` (#173)
