### PR TITLE
hedgehog-extra v0.21.0

### DIFF
--- a/changelogs/0.21.0.md
+++ b/changelogs/0.21.0.md
@@ -1,0 +1,5 @@
+## [0.21.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am21) - 2026-02-09
+
+## Changes
+
+* [`hedgehog-extra-refined4s`] Update `refined4s` to `1.16.0` (#184)


### PR DESCRIPTION
# hedgehog-extra v0.21.0
## [0.21.0](https://github.com/Kevin-Lee/scala-hedgehog-extra/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am21) - 2026-02-09

## Changes

* [`hedgehog-extra-refined4s`] Update `refined4s` to `1.16.0` (#184)
