### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,39 +4,6 @@
 [![Build Status](https://github.com/Kevin-Lee/scala-hedgehog-extra/workflows/Release/badge.svg)](https://github.com/Kevin-Lee/scala-hedgehog-extra/actions?workflow=Release)
 [![codecov](https://codecov.io/gh/Kevin-Lee/scala-hedgehog-extra/branch/main/graph/badge.svg?token=AxSbGPSGaC)](https://codecov.io/gh/Kevin-Lee/scala-hedgehog-extra)
 
-## hedgehog-extra-core
+Extra tools for Hedgehog for Scala
 
-```sbt
-"io.kevinlee" %% "hedgehog-extra-core" % "0.20.0"
-```
-
-For Scala.js and Scala Native,
-```sbt
-"io.kevinlee" %%% "hedgehog-extra-core" % "0.20.0"
-```
-
-
-## hedgehog-extra-refined
-
-```sbt
-"io.kevinlee" %% "hedgehog-extra-refined" % "0.20.0"
-```
-
-For Scala.js,
-```sbt
-"io.kevinlee" %%% "hedgehog-extra-refined" % "0.20.0"
-```
-
-
-## hedgehog-extra-refined4s
-
-For Scala 3, you have the option to use `refined4s` in place of `newtype` and `refined`, along with the support for `refined4s` provided by `hedgehog-extra`.
-
-```sbt
-"io.kevinlee" %% "hedgehog-extra-refined4s" % "0.20.0"
-```
-
-For Scala.js and Scala Native,
-```sbt
-"io.kevinlee" %%% "hedgehog-extra-refined4s" % "0.20.0"
-```
+Check out the doc site: https://hedgehog-extra.kevinly.dev

--- a/docs/latest/core/_category_.json
+++ b/docs/latest/core/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "core",
+  "position": 2,
+  "collapsible": true,
+  "collapsed": false
+}

--- a/docs/latest/core/core.md
+++ b/docs/latest/core/core.md
@@ -1,0 +1,16 @@
+---
+id: core
+title: "core module"
+---
+
+import DocCardList from '@theme/DocCardList';
+
+`hedgehog-extra-core` is the base module with reusable generators.
+
+## Import
+
+```scala mdoc
+import hedgehog.extra.{Gens, NumGens, TimeGens}
+```
+
+<DocCardList />

--- a/docs/latest/core/gens.md
+++ b/docs/latest/core/gens.md
@@ -1,0 +1,153 @@
+---
+sidebar_position: 1
+id: core-gens
+title: "Gens"
+---
+
+# `Gens`
+
+`Gens` provides foundational character and string generators.
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.Gens
+```
+
+## Non-whitespace character generator
+
+```scala mdoc
+val nonWhitespaceCharGen: Gen[Char] =
+  Gens.genNonWhitespaceChar
+```
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.runner.*
+
+object NonWhitespaceExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genNonWhitespaceChar",
+      testExampleForGenNonWhitespaceChar
+    ).withTests(5) // only for documentation to show fewer logs
+  )
+  
+  def testExampleForGenNonWhitespaceChar: Property =
+    for {
+      c <- nonWhitespaceCharGen.log("c")
+    } yield {
+      println(s"c: $c") // only for documentation to show the value
+      c.isWhitespace ==== false
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+NonWhitespaceExampleSpec.main(Array.empty)
+```
+
+## Character generator from custom ranges
+
+```scala mdoc
+val alphaNumericLikeCharGen: Gen[Char] =
+  Gens.genCharByRange(
+    List(
+      48 -> 57,
+      65 -> 90,
+      97 -> 122
+    )
+  )
+```
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.runner.*
+
+object AlphaNumericLikeCharGenSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for alphaNumericLikeCharGen",
+      testExampleForAlphaNumericLikeCharGen
+    ).withTests(5) // only for documentation to show fewer logs
+  )
+  
+  def testExampleForAlphaNumericLikeCharGen: Property =
+    for {
+      c <- alphaNumericLikeCharGen.log("c")
+    } yield {
+      println(s"c: $c") // only for documentation to show the value
+      Result.assert(c.isLetterOrDigit).log("It should be alphanumeric char")
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+AlphaNumericLikeCharGenSpec.main(Array.empty)
+```
+
+
+## Non-whitespace string generators
+
+```scala mdoc
+val tokenGen: Gen[String] =
+  Gens.genUnsafeNonWhitespaceString(16)
+
+val boundedTokenGen: Gen[String] =
+  Gens.genUnsafeNonWhitespaceStringMinMax(4, 12)
+```
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.runner.*
+
+object NonWhitespaceStringExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for tokenGen",
+      testExampleForTokenGen
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for boundedTokenGen",
+      testExampleForBoundedTokenGen
+    ).withTests(5) // only for documentation to show fewer logs
+  )
+  
+  def testExampleForTokenGen: Property =
+    for {
+      s <- tokenGen.log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(
+        s.map(_.isWhitespace ==== false).toList
+      )
+    }
+  
+  def testExampleForBoundedTokenGen: Property =
+    for {
+      s2 <- boundedTokenGen.log("s2")
+    } yield {
+      println(s"s2: $s2") // only for documentation to show the value
+      Result.all(
+        s2.map(_.isWhitespace ==== false).toList
+      )
+    }
+
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+NonWhitespaceStringExampleSpec.main(Array.empty)
+```
+
+## Constraints
+
+These are intentionally `unsafe` APIs and throw `IllegalArgumentException` for invalid bounds.
+
+```scala mdoc:crash
+Gens.genUnsafeNonWhitespaceString(0)
+```
+```scala mdoc:crash
+Gens.genUnsafeNonWhitespaceStringMinMax(0, 10)
+```
+```scala mdoc:crash
+Gens.genUnsafeNonWhitespaceStringMinMax(10, 5)
+```

--- a/docs/latest/core/num-gens.md
+++ b/docs/latest/core/num-gens.md
@@ -1,0 +1,115 @@
+---
+sidebar_position: 2
+id: core-num-gens
+title: "NumGens"
+---
+
+# `NumGens`
+
+`NumGens` provides generators that always produce ordered min/max pairs.
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.NumGens
+```
+
+## Ordered pair generators
+
+```scala mdoc
+val intPairGen: Gen[(Int, Int)] =
+  NumGens.genIntMinMaxPair(-100, 100)
+
+val longPairGen: Gen[(Long, Long)] =
+  NumGens.genLongMinMaxPair(-1000L, 1000L)
+```
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.runner.*
+
+object OrderedPairGeneratorsExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for intPairGen",
+      testExampleForIntPairGen
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for longPairGen",
+      testExampleForLongPairGen
+    ).withTests(5) // only for documentation to show fewer logs
+  )
+
+  def testExampleForIntPairGen: Property =
+    for {
+      pair <- intPairGen.log("pair")
+      (min, max) = pair
+    } yield {
+      println(s"intPair: ($min, $max)") // only for documentation to show the value
+      Result.assert(min <= max).log("Int min/max pair should satisfy min <= max")
+    }
+
+  def testExampleForLongPairGen: Property =
+    for {
+      pair <- longPairGen.log("pair")
+      (min, max) = pair
+    } yield {
+      println(s"longPair: ($min, $max)") // only for documentation to show the value
+      Result.assert(min <= max).log("Long min/max pair should satisfy min <= max")
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+OrderedPairGeneratorsExampleSpec.main(Array.empty)
+```
+
+## Functional composition with `Range`
+
+```scala mdoc
+val boundedIntGen: Gen[Int] =
+  NumGens
+    .genIntMinMaxPair(1, 50)
+    .flatMap { case (min, max) =>
+      Gen.int(Range.linear(min, max))
+    }
+```
+
+```scala mdoc
+val boundedIntWithRangeGen: Gen[(Int, Int, Int)] =
+  NumGens
+    .genIntMinMaxPair(1, 50)
+    .flatMap { case (min, max) =>
+      Gen.int(Range.linear(min, max)).map { value =>
+        (min, max, value)
+      }
+    }
+```
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.runner.*
+
+object BoundedIntGeneratorExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for boundedIntGen",
+      testExampleForBoundedIntGen
+    ).withTests(5) // only for documentation to show fewer logs
+  )
+
+  def testExampleForBoundedIntGen: Property =
+    for {
+      tuple <- boundedIntWithRangeGen.log("(min, max, value)")
+      (min, max, value) = tuple
+    } yield {
+      println(s"(min, max, value): ($min, $max, $value)") // only for documentation to show the value
+      Result
+        .assert(value >= min && value <= max)
+        .log("Generated value should stay within its generated range")
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+BoundedIntGeneratorExampleSpec.main(Array.empty)
+```

--- a/docs/latest/core/time-gens.md
+++ b/docs/latest/core/time-gens.md
@@ -1,0 +1,142 @@
+---
+sidebar_position: 3
+id: core-time-gens
+title: "TimeGens"
+---
+
+# `TimeGens`
+
+`TimeGens` provides generators for `Instant` and `LocalDate` ranges.
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.TimeGens
+import java.time.{Instant, LocalDate}
+import scala.concurrent.duration.*
+```
+
+## `Instant` generators
+
+```scala mdoc
+val fromInstant = Instant.parse("2026-01-01T00:00:00Z")
+val toInstant = Instant.parse("2026-12-31T23:59:59Z")
+
+val instantGen: Gen[Instant] =
+  TimeGens.genInstant(fromInstant, toInstant)
+
+val baseInstant = Instant.parse("2026-06-01T00:00:00Z")
+val aroundBaseInstantGen: Gen[Instant] =
+  TimeGens.genInstantFrom(baseInstant, 7.days, 14.days)
+```
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.runner.*
+
+object InstantGeneratorsExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for instantGen",
+      testExampleForInstantGen
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for aroundBaseInstantGen",
+      testExampleForAroundBaseInstantGen
+    ).withTests(5) // only for documentation to show fewer logs
+  )
+
+  def testExampleForInstantGen: Property =
+    for {
+      actual <- instantGen.log("actual")
+    } yield {
+      println(s"instant: $actual") // only for documentation to show the value
+      Result
+        .assert(!actual.isBefore(fromInstant) && !actual.isAfter(toInstant))
+        .log("Generated Instant should be in [fromInstant, toInstant]")
+    }
+
+  def testExampleForAroundBaseInstantGen: Property = {
+    val expectedFrom = baseInstant.minusMillis(7.days.toMillis)
+    val expectedTo   = baseInstant.plusMillis(14.days.toMillis)
+
+    for {
+      actual <- aroundBaseInstantGen.log("actual")
+    } yield {
+      println(s"aroundBaseInstant: $actual") // only for documentation to show the value
+      Result
+        .assert(!actual.isBefore(expectedFrom) && !actual.isAfter(expectedTo))
+        .log("Generated Instant should be in [baseInstant - 7.days, baseInstant + 14.days]")
+    }
+  }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+InstantGeneratorsExampleSpec.main(Array.empty)
+```
+
+## `LocalDate` generators
+
+```scala mdoc
+val fromDate = LocalDate.parse("2026-01-01")
+val toDate = LocalDate.parse("2026-12-31")
+
+val localDateGen: Gen[LocalDate] =
+  TimeGens.genLocalDate(fromDate, toDate)
+
+val baseDate = LocalDate.parse("2026-06-01")
+val aroundBaseDateGen: Gen[LocalDate] =
+  TimeGens.genLocalDateFrom(baseDate, 30.days, 30.days)
+```
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.runner.*
+
+object LocalDateGeneratorsExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for localDateGen",
+      testExampleForLocalDateGen
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for aroundBaseDateGen",
+      testExampleForAroundBaseDateGen
+    ).withTests(5) // only for documentation to show fewer logs
+  )
+
+  def testExampleForLocalDateGen: Property =
+    for {
+      actual <- localDateGen.log("actual")
+    } yield {
+      println(s"localDate: $actual") // only for documentation to show the value
+      Result
+        .assert(
+          (actual.isEqual(fromDate) || actual.isAfter(fromDate)) &&
+            (actual.isEqual(toDate) || actual.isBefore(toDate))
+        )
+        .log("Generated LocalDate should be in [fromDate, toDate]")
+    }
+
+  def testExampleForAroundBaseDateGen: Property = {
+    val expectedFrom = baseDate.minusDays(30.days.toDays)
+    val expectedTo   = baseDate.plusDays(30.days.toDays)
+
+    for {
+      actual <- aroundBaseDateGen.log("actual")
+    } yield {
+      println(s"aroundBaseDate: $actual") // only for documentation to show the value
+      Result
+        .assert(
+          (actual.isEqual(expectedFrom) || actual.isAfter(expectedFrom)) &&
+            (actual.isEqual(expectedTo) || actual.isBefore(expectedTo))
+        )
+        .log("Generated LocalDate should be in [baseDate - 30.days, baseDate + 30.days]")
+    }
+  }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+LocalDateGeneratorsExampleSpec.main(Array.empty)
+```

--- a/docs/latest/intro.md
+++ b/docs/latest/intro.md
@@ -39,13 +39,12 @@ Hedgehog Extra also supports Scala.js and Scala Native.
 :::
 
 ## Getting Started
-
 To get `hedgehog-extra` for your project,
 
-### hedgehog-extra-core
+### `hedgehog-extra-core`
 
 <Tabs
-groupId="hedgehog-extra"
+groupId="hedgehog-extra-core"
 defaultValue="hedgehog-extra-sbt"
 values={[
 {label: 'sbt', value: 'hedgehog-extra-sbt'},
@@ -66,7 +65,7 @@ or for Scala.js and Scala Native
 "io.kevinlee" %%% "hedgehog-extra-core" % "@VERSION@"
 ```
 
-  </TabItem>
+</TabItem>
 
   <TabItem value="hedgehog-extra-sbt-lib">
 
@@ -95,7 +94,7 @@ libraryDependencies += "io.kevinlee" %%% "hedgehog-extra-core" % "@VERSION@"
 
 ***
 
-### hedgehog-extra-refined4s
+### `hedgehog-extra-refined4s`
 
 **For Scala 3**, you have the option to use `refined4s` in place of `newtype` and `refined`, along with the support for `refined4s` provided by `hedgehog-extra`.
 
@@ -121,7 +120,7 @@ or for Scala.js and Scala Native
 "io.kevinlee" %%% "hedgehog-extra-refined4s" % "@VERSION@"
 ```
 
-  </TabItem>
+</TabItem>
 
   <TabItem value="hedgehog-extra-sbt-lib">
 
@@ -150,8 +149,7 @@ libraryDependencies += "io.kevinlee" %%% "hedgehog-extra-refined4s" % "@VERSION@
 
 ***
 
-
-### hedgehog-extra-refined
+### `hedgehog-extra-refined`
 
 <Tabs
 groupId="hedgehog-extra"
@@ -175,7 +173,7 @@ or for Scala.js
 "io.kevinlee" %%% "hedgehog-extra-refined" % "@VERSION@"
 ```
 
-  </TabItem>
+</TabItem>
 
   <TabItem value="hedgehog-extra-sbt-lib">
 
@@ -285,5 +283,22 @@ libraryDependencies ++= Seq(
   </TabItem>
 </Tabs>
 
-## MORE TO BE ADDED LATER
+## Documentation
 
+- [core module](/docs/core)
+- [refined4s module](/docs/refined4s)
+- [refined module](/docs/refined)
+
+## Quick Start (Functional Composition)
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.Gens
+import hedgehog.extra.NumGens
+
+val userCodeGen: Gen[String] =
+  for {
+    (min, max) <- NumGens.genIntMinMaxPair(4, 12)
+    suffix     <- Gens.genUnsafeNonWhitespaceStringMinMax(min, max)
+  } yield s"user-$suffix"
+```

--- a/docs/latest/intro.md
+++ b/docs/latest/intro.md
@@ -97,7 +97,7 @@ libraryDependencies += "io.kevinlee" %%% "hedgehog-extra-core" % "@VERSION@"
 
 ### hedgehog-extra-refined4s
 
-For Scala 3, you have the option to use `refined4s` in place of `newtype` and `refined`, along with the support for `refined4s` provided by `hedgehog-extra`.
+**For Scala 3**, you have the option to use `refined4s` in place of `newtype` and `refined`, along with the support for `refined4s` provided by `hedgehog-extra`.
 
 <Tabs
 groupId="hedgehog-extra"

--- a/docs/latest/refined/_category_.json
+++ b/docs/latest/refined/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "refined",
+  "position": 4,
+  "collapsible": true,
+  "collapsed": false
+}

--- a/docs/latest/refined/net-gens.md
+++ b/docs/latest/refined/net-gens.md
@@ -1,0 +1,124 @@
+---
+sidebar_position: 3
+id: refined-net-gens
+title: "NetGens"
+---
+
+# `refined` `NetGens`
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.refined.NetGens
+import eu.timepit.refined.types.net.*
+```
+
+## Port generators
+
+```scala mdoc
+val genPortNumber: Gen[PortNumber] =
+  NetGens.genPortNumber
+
+val genSystemPortNumber: Gen[SystemPortNumber] =
+  NetGens.genSystemPortNumber
+
+val genUserPortNumber: Gen[UserPortNumber] =
+  NetGens.genUserPortNumber
+
+val genDynamicPortNumber: Gen[DynamicPortNumber] =
+  NetGens.genDynamicPortNumber
+
+val genNonSystemPortNumber: Gen[NonSystemPortNumber] =
+  NetGens.genNonSystemPortNumber
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined.NetGens
+
+object NetGensExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genPortNumber",
+      testExampleForGenPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genSystemPortNumber",
+      testExampleForGenSystemPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genUserPortNumber",
+      testExampleForGenUserPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genDynamicPortNumber",
+      testExampleForGenDynamicPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonSystemPortNumber",
+      testExampleForGenNonSystemPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenPortNumber: Property =
+    for {
+      p <- NetGens.genPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 0", p.value, 0)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 65535", p.value, 65535)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenSystemPortNumber: Property =
+    for {
+      p <- NetGens.genSystemPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 0", p.value, 0)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 1023", p.value, 1023)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenUserPortNumber: Property =
+    for {
+      p <- NetGens.genUserPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 1024", p.value, 1024)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 49151", p.value, 49151)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenDynamicPortNumber: Property =
+    for {
+      p <- NetGens.genDynamicPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 49152", p.value, 49152)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 65535", p.value, 65535)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenNonSystemPortNumber: Property =
+    for {
+      p <- NetGens.genNonSystemPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 1024", p.value, 1024)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 65535", p.value, 65535)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+NetGensExampleSpec.main(Array.empty)
+```

--- a/docs/latest/refined/num-gens.md
+++ b/docs/latest/refined/num-gens.md
@@ -1,0 +1,167 @@
+---
+sidebar_position: 1
+id: refined-num-gens
+title: "NumGens"
+---
+
+# `refined` `NumGens`
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.refined.NumGens
+import eu.timepit.refined.types.numeric.*
+```
+
+## Numeric refined generators
+
+```scala mdoc
+val genNegInt: Gen[NegInt] =
+  NumGens.genNegInt(NegInt.unsafeFrom(-100), NegInt.unsafeFrom(-1))
+
+val genPosInt: Gen[PosInt] =
+  NumGens.genPosInt(PosInt.unsafeFrom(1), PosInt.unsafeFrom(100))
+
+val genNonNegLong: Gen[NonNegLong] =
+  NumGens.genNonNegLong(NonNegLong.unsafeFrom(0L), NonNegLong.unsafeFrom(1000L))
+
+val genNonPosDouble: Gen[NonPosDouble] =
+  NumGens.genNonPosDouble(NonPosDouble.unsafeFrom(-10.0), NonPosDouble.unsafeFrom(0.0))
+
+// and there are more...
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined.NumGens
+
+import eu.timepit.refined.types.numeric.*
+
+object NumGensExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genNegInt",
+      testExampleForGenNegInt
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genPosInt",
+      testExampleForGenPosInt
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonNegLong",
+      testExampleForGenNonNegLong
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonPosDouble",
+      testExampleForGenNonPosDouble
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenNegInt: Property =
+    for {
+      n <- NumGens.genNegInt(NegInt.unsafeFrom(-100), NegInt.unsafeFrom(-1)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= -100", n.value, -100)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= -1", n.value, -1)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenPosInt: Property =
+    for {
+      n <- NumGens.genPosInt(PosInt.unsafeFrom(1), PosInt.unsafeFrom(100)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 1", n.value, 1)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 100", n.value, 100)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenNonNegLong: Property =
+    for {
+      n <- NumGens.genNonNegLong(NonNegLong.unsafeFrom(0L), NonNegLong.unsafeFrom(1000L)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 0L", n.value, 0L)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 1000L", n.value, 1000L)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenNonPosDouble: Property =
+    for {
+      n <- NumGens.genNonPosDouble(NonPosDouble.unsafeFrom(-10.0), NonPosDouble.unsafeFrom(0.0)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= -10.0d", n.value, -10.0d)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 0.0d", n.value, 0.0d)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+NumGensExampleSpec.main(Array.empty)
+```
+
+## Helper variants
+
+```scala mdoc
+val genNegIntMinTo: Gen[NegInt] =
+  NumGens.genNegIntMinTo(NegInt.unsafeFrom(-500))
+
+val genPosLongMaxTo: Gen[PosLong] =
+  NumGens.genPosLongMaxTo(PosLong.unsafeFrom(10000L))
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined.NumGens
+
+import eu.timepit.refined.types.numeric.*
+
+object NumGensVariantsExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genNegIntMinTo",
+      testExampleForGenNegIntMinTo
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genPosLongMaxTo",
+      testExampleForGenPosLongMaxTo
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenNegIntMinTo: Property =
+    for {
+      n <- NumGens.genNegIntMinTo(NegInt.unsafeFrom(-500)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= -500", n.value, -500)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= -1", n.value, -1)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenPosLongMaxTo: Property =
+    for {
+      n <- NumGens.genPosLongMaxTo(PosLong.unsafeFrom(10000L)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 1L", n.value, 1L)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 10000L", n.value, 10000L)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+NumGensVariantsExampleSpec.main(Array.empty)
+```

--- a/docs/latest/refined/refined.md
+++ b/docs/latest/refined/refined.md
@@ -1,0 +1,16 @@
+---
+id: refined
+title: "refined module"
+---
+
+import DocCardList from '@theme/DocCardList';
+
+`hedgehog-extra-refined` provides generators for `eu.timepit.refined` types.
+
+## Import
+
+```scala mdoc
+import hedgehog.extra.refined.{NetGens, NumGens, StringGens, TimeGens}
+```
+
+<DocCardList />

--- a/docs/latest/refined/string-gens.md
+++ b/docs/latest/refined/string-gens.md
@@ -1,0 +1,137 @@
+---
+sidebar_position: 2
+id: refined-string-gens
+title: "StringGens"
+---
+
+# `refined` `StringGens`
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.refined.StringGens
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
+```
+
+## Non-whitespace string generators
+
+```scala mdoc
+val genNonWhitespaceString: Gen[NonEmptyString] =
+  StringGens.genNonWhitespaceString(PosInt.unsafeFrom(20))
+
+val genNonWhitespaceStringMinMax: Gen[NonEmptyString] =
+  StringGens.genNonWhitespaceStringMinMax(PosInt.unsafeFrom(3), PosInt.unsafeFrom(12))
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined.StringGens
+
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
+
+object StringGensExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genNonWhitespaceString",
+      testExampleForGenNonWhitespaceString
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonWhitespaceStringMinMax",
+      testExampleForGenNonWhitespaceStringMinMax
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenNonWhitespaceString: Property =
+    for {
+      s <- StringGens.genNonWhitespaceString(PosInt.unsafeFrom(20)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result.assert(!s.value.exists(_.isWhitespace)).log(s"The value [$s] must not contain whitespace"),
+      ))
+    }
+
+  def testExampleForGenNonWhitespaceStringMinMax: Property =
+    for {
+      s <- StringGens.genNonWhitespaceStringMinMax(PosInt.unsafeFrom(3), PosInt.unsafeFrom(12)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result.assert(!s.value.exists(_.isWhitespace)).log(s"The value [$s] must not contain whitespace"),
+        Result.diffNamed(s"The length of [$s] must be >= 3", s.value.length, 3)(_ >= _),
+        Result.diffNamed(s"The length of [$s] must be <= 12", s.value.length, 12)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+StringGensExampleSpec.main(Array.empty)
+```
+
+## Custom character generator variants
+
+```scala mdoc
+val genNonEmptyStringAlphaNum: Gen[NonEmptyString] =
+  StringGens.genNonEmptyString(Gen.alphaNum, PosInt.unsafeFrom(20))
+
+val genNonEmptyStringUnicode: Gen[NonEmptyString] =
+  StringGens.genNonEmptyStringMinMax(Gen.unicodeAll, PosInt.unsafeFrom(2), PosInt.unsafeFrom(10))
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined.StringGens
+
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
+
+object StringGensCustomCharExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genNonEmptyStringAlphaNum",
+      testExampleForGenNonEmptyStringAlphaNum
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonEmptyStringUnicode",
+      testExampleForGenNonEmptyStringUnicode
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenNonEmptyStringAlphaNum: Property =
+    for {
+      s <- StringGens.genNonEmptyString(Gen.alphaNum, PosInt.unsafeFrom(20)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result
+          .assert(s.value.forall(c => c.isDigit || ('a' to 'z').contains(c) || ('A' to 'Z').contains(c)))
+          .log(s"The value [$s] must contain only alphabet or digit"),
+      ))
+    }
+
+  def testExampleForGenNonEmptyStringUnicode: Property =
+    for {
+      s <- StringGens.genNonEmptyStringMinMax(Gen.unicodeAll, PosInt.unsafeFrom(2), PosInt.unsafeFrom(10)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result.diffNamed(s"The length of [$s] must be >= 2", s.value.length, 2)(_ >= _),
+        Result.diffNamed(s"The length of [$s] must be <= 10", s.value.length, 10)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+StringGensCustomCharExampleSpec.main(Array.empty)
+```

--- a/docs/latest/refined/time-gens.md
+++ b/docs/latest/refined/time-gens.md
@@ -1,0 +1,165 @@
+---
+sidebar_position: 4
+id: refined-time-gens
+title: "TimeGens"
+---
+
+# `refined` `TimeGens`
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.refined.TimeGens
+import eu.timepit.refined.types.time.*
+```
+
+## Time-part generators
+
+```scala mdoc
+val genMonth: Gen[Month] =
+  TimeGens.genMonth
+
+val genBusinessHour: Gen[Hour] =
+  TimeGens.genHourMinMax(Hour.unsafeFrom(9), Hour.unsafeFrom(17))
+
+val genSecond: Gen[Second] =
+  TimeGens.genSecond
+
+val genMillis: Gen[Millis] =
+  TimeGens.genMillis
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined.TimeGens
+
+import eu.timepit.refined.types.time.*
+
+object TimeGensExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genMonth",
+      testExampleForGenMonth
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genBusinessHour",
+      testExampleForGenBusinessHour
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genSecond",
+      testExampleForGenSecond
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genMillis",
+      testExampleForGenMillis
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenMonth: Property =
+    for {
+      n <- TimeGens.genMonth.log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 1", n.value, 1)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 12", n.value, 12)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenBusinessHour: Property =
+    for {
+      n <- TimeGens.genHourMinMax(Hour.unsafeFrom(9), Hour.unsafeFrom(17)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 9", n.value, 9)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 17", n.value, 17)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenSecond: Property =
+    for {
+      n <- TimeGens.genSecond.log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 0", n.value, 0)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 59", n.value, 59)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenMillis: Property =
+    for {
+      n <- TimeGens.genMillis.log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 0", n.value, 0)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 999", n.value, 999)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+TimeGensExampleSpec.main(Array.empty)
+```
+
+## Bounded generators
+
+```scala mdoc
+val genFirstQuarterMonth: Gen[Month] =
+  TimeGens.genMonthMinMax(Month.unsafeFrom(1), Month.unsafeFrom(3))
+
+val genFirstTenDays: Gen[Day] =
+  TimeGens.genDayMinMax(Day.unsafeFrom(1), Day.unsafeFrom(10))
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined.TimeGens
+
+import eu.timepit.refined.types.time.*
+
+object TimeGensBoundedExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genFirstQuarterMonth",
+      testExampleForGenFirstQuarterMonth
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genFirstTenDays",
+      testExampleForGenFirstTenDays
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenFirstQuarterMonth: Property =
+    for {
+      n <- TimeGens.genMonthMinMax(Month.unsafeFrom(1), Month.unsafeFrom(3)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 1", n.value, 1)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 3", n.value, 3)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenFirstTenDays: Property =
+    for {
+      n <- TimeGens.genDayMinMax(Day.unsafeFrom(1), Day.unsafeFrom(10)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 1", n.value, 1)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 10", n.value, 10)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+TimeGensBoundedExampleSpec.main(Array.empty)
+```

--- a/docs/latest/refined4s/_category_.json
+++ b/docs/latest/refined4s/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "refined4s",
+  "position": 3,
+  "collapsible": true,
+  "collapsed": false
+}

--- a/docs/latest/refined4s/network-gens.md
+++ b/docs/latest/refined4s/network-gens.md
@@ -1,0 +1,124 @@
+---
+sidebar_position: 3
+id: refined4s-network-gens
+title: "NetworkGens"
+---
+
+# `refined4s` `NetworkGens`
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.refined4s.gens.NetworkGens
+import refined4s.types.all.*
+```
+
+## Port generators
+
+```scala mdoc
+val genPortNumber: Gen[PortNumber] =
+  NetworkGens.genPortNumber
+
+val genSystemPortNumber: Gen[SystemPortNumber] =
+  NetworkGens.genSystemPortNumber
+
+val genUserPortNumber: Gen[UserPortNumber] =
+  NetworkGens.genUserPortNumber
+
+val genDynamicPortNumber: Gen[DynamicPortNumber] =
+  NetworkGens.genDynamicPortNumber
+
+val genNonSystemPortNumber: Gen[NonSystemPortNumber] =
+  NetworkGens.genNonSystemPortNumber
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined4s.gens.NetworkGens
+
+object NetworkGensExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genPortNumber",
+      testExampleForGenPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genSystemPortNumber",
+      testExampleForGenSystemPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genUserPortNumber",
+      testExampleForGenUserPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genDynamicPortNumber",
+      testExampleForGenDynamicPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonSystemPortNumber",
+      testExampleForGenNonSystemPortNumber
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenPortNumber: Property =
+    for {
+      p <- NetworkGens.genPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 0", p.value, 0)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 65535", p.value, 65535)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenSystemPortNumber: Property =
+    for {
+      p <- NetworkGens.genSystemPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 0", p.value, 0)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 1023", p.value, 1023)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenUserPortNumber: Property =
+    for {
+      p <- NetworkGens.genUserPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 1024", p.value, 1024)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 49151", p.value, 49151)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenDynamicPortNumber: Property =
+    for {
+      p <- NetworkGens.genDynamicPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 49152", p.value, 49152)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 65535", p.value, 65535)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenNonSystemPortNumber: Property =
+    for {
+      p <- NetworkGens.genNonSystemPortNumber.log("p")
+    } yield {
+      println(s"p: $p") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$p] must be >= 1024", p.value, 1024)(_ >= _),
+        Result.diffNamed(s"The value [$p] must be <= 65535", p.value, 65535)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+NetworkGensExampleSpec.main(Array.empty)
+```

--- a/docs/latest/refined4s/num-gens.md
+++ b/docs/latest/refined4s/num-gens.md
@@ -1,0 +1,164 @@
+---
+sidebar_position: 1
+id: refined4s-num-gens
+title: "NumGens"
+---
+
+# `refined4s` `NumGens`
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.refined4s.gens.NumGens
+import refined4s.types.all.*
+```
+
+## Numeric refined generators
+
+```scala mdoc
+val genNegInt: Gen[NegInt] =
+  NumGens.genNegInt(NegInt(-100), NegInt(-1))
+
+val genPosInt: Gen[PosInt] =
+  NumGens.genPosInt(PosInt(1), PosInt(100))
+
+val genNonNegLong: Gen[NonNegLong] =
+  NumGens.genNonNegLong(NonNegLong(0L), NonNegLong(1000L))
+
+val genPosDouble: Gen[PosDouble] =
+  NumGens.genPosDouble(PosDouble(0.1d), PosDouble(100d))
+
+// and there are more... 
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined4s.gens.NumGens
+
+import refined4s.types.all.*
+
+object NumGensExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genNegInt",
+      testExampleForGenNegInt
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genPosInt",
+      testExampleForGenPosInt
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonNegLong",
+      testExampleForGenNonNegLong
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genPosDouble",
+      testExampleForGenPosDouble
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenNegInt: Property =
+    for {
+      n <- NumGens.genNegInt(NegInt(-100), NegInt(-1)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= -100", n.value, -100)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= -1", n.value, -1)(_ <= _),
+      ))
+    }
+  
+  def testExampleForGenPosInt: Property =
+    for {
+      n <- NumGens.genPosInt(PosInt(1), PosInt(100)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 1", n.value, 1)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 100", n.value, 100)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenNonNegLong: Property =
+    for {
+      n <- NumGens.genNonNegLong(NonNegLong(0L), NonNegLong(1000L)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 0L", n.value, 0L)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 1000L", n.value, 1000L)(_ <= _),
+      ))
+    }
+  
+  def testExampleForGenPosDouble: Property =
+    for {
+      n <- NumGens.genPosDouble(PosDouble(0.1d), PosDouble(100d)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.all(List(
+        Result.diffNamed(s"The value [$n] must be >= 0.1d", n.value, 0.1d)(_ >= _),
+        Result.diffNamed(s"The value [$n] must be <= 100d", n.value, 100d)(_ <= _),
+      ))
+    }
+
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+NumGensExampleSpec.main(Array.empty)
+```
+
+
+## Helper variants
+
+```scala mdoc
+val anyNegIntFrom: Gen[NegInt] =
+  NumGens.genNegIntMinTo(NegInt(-500))
+
+val anyNonNegIntUpTo: Gen[NonNegInt] =
+  NumGens.genNonNegIntMaxTo(NonNegInt(1000))
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined4s.gens.NumGens
+
+import refined4s.types.all.*
+
+object NumGensVariantsExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genNegIntMinTo",
+      testExampleForGenNegIntMinTo
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonNegIntMaxTo",
+      testExampleForGenNonNegIntMaxTo
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenNegIntMinTo: Property =
+    for {
+      n <- NumGens.genNegIntMinTo(NegInt(-500)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.diffNamed(s"The value [$n] must be >= -500", n.value, -500)(_ >= _)
+    }
+  
+  def testExampleForGenNonNegIntMaxTo: Property =
+    for {
+      n <- NumGens.genNonNegIntMaxTo(NonNegInt(1000)).log("n")
+    } yield {
+      println(s"n: $n") // only for documentation to show the value
+      Result.diffNamed(s"The value [$n] must be <= 1000", n.value, 1000)(_ <= _)
+    }
+
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+NumGensVariantsExampleSpec.main(Array.empty)
+```

--- a/docs/latest/refined4s/refined4s.md
+++ b/docs/latest/refined4s/refined4s.md
@@ -1,0 +1,16 @@
+---
+id: refined4s
+title: "refined4s module"
+---
+
+import DocCardList from '@theme/DocCardList';
+
+`hedgehog-extra-refined4s` provides generators for `refined4s` pre-defined types.
+
+## Import
+
+```scala mdoc
+import hedgehog.extra.refined4s.gens.{NetworkGens, NumGens, StringGens}
+```
+
+<DocCardList />

--- a/docs/latest/refined4s/string-gens.md
+++ b/docs/latest/refined4s/string-gens.md
@@ -1,0 +1,208 @@
+---
+sidebar_position: 2
+id: refined4s-string-gens
+title: "StringGens"
+---
+
+# `refined4s` `StringGens`
+
+## Import
+
+```scala mdoc
+import hedgehog.*
+import hedgehog.extra.refined4s.gens.StringGens
+import refined4s.types.all.*
+```
+
+## Non-empty and non-blank string generators
+
+```scala mdoc
+val genNonWhitespaceString: Gen[NonEmptyString] =
+  StringGens.genNonWhitespaceString(PosInt(24))
+
+val genNonWhitespaceStringMinMax: Gen[NonEmptyString] =
+  StringGens.genNonWhitespaceStringMinMax(PosInt(4), PosInt(12))
+
+val genNonBlankString: Gen[NonBlankString] =
+  StringGens.genNonBlankString(PosInt(24))
+
+val genNonBlankStringMinMax: Gen[NonBlankString] =
+  StringGens.genNonBlankStringMinMax(PosInt(3), PosInt(12))
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined4s.gens.StringGens
+
+import refined4s.types.all.*
+
+object StringGensExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genNonWhitespaceString",
+      testExampleForGenNonWhitespaceString
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonWhitespaceStringMinMax",
+      testExampleForGenNonWhitespaceStringMinMax
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonBlankString",
+      testExampleForGenNonBlankString
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonBlankStringMinMax",
+      testExampleForGenNonBlankStringMinMax
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenNonWhitespaceString: Property =
+    for {
+      s <- StringGens.genNonWhitespaceString(PosInt(24)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result.assert(!s.value.exists(_.isWhitespace)).log(s"The value [$s] must not contain whitespace")
+      ))
+    }
+
+  def testExampleForGenNonWhitespaceStringMinMax: Property =
+    for {
+      s <- StringGens.genNonWhitespaceStringMinMax(PosInt(4), PosInt(12)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result.assert(!s.value.exists(_.isWhitespace)).log(s"The value [$s] must not contain whitespace"),
+        Result.diffNamed(s"The length of [$s] must be >= 4", s.value.length, 4)(_ >= _),
+        Result.diffNamed(s"The length of [$s] must be <= 12", s.value.length, 12)(_ <= _),
+      ))
+    }
+
+  def testExampleForGenNonBlankString: Property =
+    for {
+      s <- StringGens.genNonBlankString(PosInt(24)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result.assert(!s.value.exists(_.isWhitespace)).log(s"The value [$s] must not contain whitespace"),
+      ))
+    }
+
+  def testExampleForGenNonBlankStringMinMax: Property =
+    for {
+      s <- StringGens.genNonBlankStringMinMax(PosInt(3), PosInt(12)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result.assert(!s.value.exists(_.isWhitespace)).log(s"The value [$s] must not contain whitespace"),
+        Result.diffNamed(s"The length of [$s] must be >= 3", s.value.length, 3)(_ >= _),
+        Result.diffNamed(s"The length of [$s] must be <= 12", s.value.length, 12)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+StringGensExampleSpec.main(Array.empty)
+```
+
+## Custom character generator variants
+
+```scala mdoc
+val genNonEmptyStringAlphaNum: Gen[NonEmptyString] =
+  StringGens.genNonEmptyString(Gen.alphaNum, PosInt(16))
+
+val genNonEmptyStringUnicode: Gen[NonEmptyString] =
+  StringGens.genNonEmptyStringMinMax(Gen.unicodeAll, PosInt(2), PosInt(10))
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined4s.gens.StringGens
+
+import refined4s.types.all.*
+
+object StringGensCustomCharExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genNonEmptyStringAlphaNum",
+      testExampleForGenNonEmptyStringAlphaNum
+    ).withTests(5), // only for documentation to show fewer logs
+    property(
+      "Example for genNonEmptyStringUnicode",
+      testExampleForGenNonEmptyStringUnicode
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenNonEmptyStringAlphaNum: Property =
+    for {
+      s <- StringGens.genNonEmptyString(Gen.alphaNum, PosInt(16)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result
+          .assert(s.value.forall(c => c.isDigit || ('a' to 'z').contains(c) || ('A' to 'Z').contains(c)))
+          .log(s"The value [$s] must contain only alphabet or digit"),
+      ))
+    }
+
+  def testExampleForGenNonEmptyStringUnicode: Property =
+    for {
+      s <- StringGens.genNonEmptyStringMinMax(Gen.unicodeAll, PosInt(2), PosInt(10)).log("s")
+    } yield {
+      println(s"s: $s") // only for documentation to show the value
+      Result.all(List(
+        Result.assert(s.value.nonEmpty).log(s"The value [$s] must be non-empty"),
+        Result.diffNamed(s"The length of [$s] must be >= 2", s.value.length, 2)(_ >= _),
+        Result.diffNamed(s"The length of [$s] must be <= 10", s.value.length, 10)(_ <= _),
+      ))
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+StringGensCustomCharExampleSpec.main(Array.empty)
+```
+
+## UUID generator
+
+```scala mdoc
+val genUuid: Gen[Uuid] =
+  StringGens.genUuid
+```
+
+```scala mdoc:reset
+import hedgehog.*
+import hedgehog.runner.*
+
+import hedgehog.extra.refined4s.gens.StringGens
+
+object StringGensUuidExampleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Example for genUuid",
+      testExampleForGenUuid
+    ).withTests(5), // only for documentation to show fewer logs
+  )
+
+  def testExampleForGenUuid: Property =
+    for {
+      uuid <- StringGens.genUuid.log("uuid")
+    } yield {
+      println(s"uuid: $uuid") // only for documentation to show the value
+      val expected = java.util.UUID.fromString(uuid.value)
+      val actual   = uuid.toUUID
+      actual ==== expected
+    }
+}
+
+// This is only for doc. Your test code should be run by sbt (or maybe another build tool)
+StringGensUuidExampleSpec.main(Array.empty)
+```


### PR DESCRIPTION
# Update docs

* Update: README.md with simplified content and doc site link
* Update: emphasize Scala 3 support for `refined4s` in intro docs
* Update: improve intro docs with better formatting and quick start example

## Update docs: add documentation for `hedgehog-extra-core` module

- Add documentation for `Gens` covering character and string generators.
- Add documentation for `NumGens` covering ordered pair generators.
- Add documentation for `TimeGens` covering `Instant` and `LocalDate` generators.
- Include `_category_.json` for the core module sidebar organization.

## Update docs: Adds documentation for `hedgehog-extra-refined4s` module including:
- Introduction page for `refined4s` module
- `NetworkGens` documentation with port generator examples
- `NumGens` documentation with numeric generator examples
- `StringGens` documentation with non-empty/non-blank string and UUID examples
- Category configuration for `refined4s` documentation section

## Update docs: add documentation for `refined` module

- Add introduction page for `hedgehog-extra-refined`.
- Add detailed documentation and mdoc examples for `NetGens`, `NumGens`, `StringGens`, and `TimeGens`.
- Configure documentation category for the refined module.